### PR TITLE
src: onboarding_seed_sskr.c: Use stable cx_crc32 instead of cx_crc32_hw

### DIFF
--- a/src/ux_common/onboarding_seed_sskr.c
+++ b/src/ux_common/onboarding_seed_sskr.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <os.h>
 #include <cx.h>
+#include <lib_cxng/src/cx_crc.h>  // until cx_crc32 is properly define in lib_cxng/include/lcx_crc.h
 
 #include "onboarding_seed_rom_variables.h"
 #include "common_bip39.h"
@@ -10,9 +11,9 @@
 
 // Return the CRC-32 checksum of the input buffer in network byte order (big endian).
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#define crc32_nbo(...) cx_crc32_hw(__VA_ARGS__)
+#define crc32_nbo(...) cx_crc32(__VA_ARGS__)
 #elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#define crc32_nbo(...) os_swap_u32(cx_crc32_hw(__VA_ARGS__))
+#define crc32_nbo(...) os_swap_u32(cx_crc32(__VA_ARGS__))
 #else
 #error "What kind of system is this?"
 #endif

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -112,7 +112,7 @@ FetchContent_MakeAvailable(cmocka)
 add_compile_definitions(TEST DEBUG=0 SKIP_FOR_CMOCKA)
 add_compile_definitions(TARGET_NANOS HAVE_HASH HAVE_HMAC HAVE_SHA224 HAVE_SHA256 HAVE_SHA512 HAVE_PBKDF2 HAVE_ECC HAVE_CRC HAVE_RNG IO_HID_EP_LENGTH=64)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib $ENV{LEDGER_SECURE_SDK}/include $ENV{LEDGER_SECURE_SDK}/lib_cxng/src $ENV{LEDGER_SECURE_SDK}/lib_cxng/include $ENV{LEDGER_SECURE_SDK}/lib_ux/include $ENV{LEDGER_SECURE_SDK}/lib_bagl/include)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib $ENV{LEDGER_SECURE_SDK}/include $ENV{LEDGER_SECURE_SDK} $ENV{LEDGER_SECURE_SDK}/lib_cxng/src $ENV{LEDGER_SECURE_SDK}/lib_cxng/include $ENV{LEDGER_SECURE_SDK}/lib_ux/include $ENV{LEDGER_SECURE_SDK}/lib_bagl/include)
 
 # add src
 install_apk_packages(linux-headers)

--- a/tests/unit/lib/bolos/cxlib.h
+++ b/tests/unit/lib/bolos/cxlib.h
@@ -216,7 +216,7 @@ cx_err_t cx_ecdomain_generator_bn(cx_curve_t cv, cx_ecpoint_t *P);
 unsigned int sys_get_api_level(void);
 cx_err_t cx_get_random_bytes(void *buffer, size_t len);
 cx_err_t cx_trng_get_random_data(void *buffer, size_t len);
-uint32_t cx_crc32_hw(const void *_buf, size_t len);
+uint32_t cx_crc32(const void *_buf, size_t len);
 
 // cx_aes_sdk2.c
 cx_err_t cx_aes_set_key_hw(const cx_aes_key_t *key, uint32_t mode);

--- a/tests/unit/lib/testutils.c
+++ b/tests/unit/lib/testutils.c
@@ -27,7 +27,7 @@ char os_secure_memcmp(const void *src1, const void *src2, size_t length)
     return xoracc;
 }
 
-uint32_t cx_crc32_hw(const void *buf, size_t len)
+uint32_t cx_crc32(const void *buf, size_t len)
 {
   uint32_t crc;
   crc = cx_crc32_update(0xFFFFFFFF, buf, len);


### PR DESCRIPTION
Duplicate of https://github.com/LedgerHQ/app-seed-tool/pull/1 to make sure we keep an common history with @aido repo at least for now